### PR TITLE
Remove leftover uwsgi copy in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ FROM python:3.13-slim-bookworm
 
 COPY --from=builder /usr/src/app/.venv/lib/python3.13/site-packages/ /usr/local/lib/python3.13/site-packages
 COPY --from=builder /usr/src/app /usr/src/app
-COPY --from=builder /usr/src/app/.venv/bin/uwsgi /usr/local/bin/
 WORKDIR /usr/src/app
 
 RUN python manage.py collectstatic --no-input


### PR DESCRIPTION
# Description

This was left over when swapping from unwsgi to gunicorn in #44. Note that we can't straightforwardly copy over the gunicorn binary from the build stage because it has a shebang pointing directly to the uv virtual environment from the build stage which is in a different location in the second stage. We can still use `python -m gunicorn` however.

Close #50 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))
