### PR TITLE
Automate deployment to Azure App service

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Build and Publish
 on:
   push:
     branches:
-      - 65-automate-deployment-to-app-service
+      - main
 
 jobs:
   build-and-publish:


### PR DESCRIPTION
# Description

- Added deployment to Azure Web app.  Followed the official [tutorial](https://learn.microsoft.com/en-us/azure/app-service/deploy-container-github-action?tabs=publish-profile&pivots=github-actions-containers-linux) and used `github.sha` for image tagging. 
- Tested the deployment by temporary triggering jobs on pushes to working branch.

When moving to `prod`, github `AZURE_WEBAPP_PUBLISH_PROFILE` should be updated to reflect the new web app.

Close #65 


