### PR TITLE
Set ranges in second trajectory plot

### DIFF
--- a/main/plots.py
+++ b/main/plots.py
@@ -235,6 +235,8 @@ def create_solar_orbiter_plot(
     y_axis_label: str,
     unit: Literal["AU", "angle"],
     radii: list[float],
+    x_range: tuple[float, float] | None = None,
+    y_range: tuple[float, float] | None = None,
 ) -> figure:
     """Create a plot for the Solar Orbiter trajectory.
 
@@ -245,6 +247,8 @@ def create_solar_orbiter_plot(
         unit: Whether to plot in AU (the fixed Earth frame) or angle (the Earth-Sun-
             spacecraft angle).
         radii: A list of radii for plotting dashed circles.
+        x_range: Optional x-range for the plot.
+        y_range: Optional y-range for the plot.
 
     Returns:
         A Bokeh figure containing the trajectory of Solar Orbiter in the fixed
@@ -292,6 +296,12 @@ def create_solar_orbiter_plot(
     hover = HoverTool(tooltips=[("ID", "@name")], renderers=[objects])
     plot.add_tools(hover)
 
+    # Set axis ranges if provided
+    if y_range is not None:
+        plot.y_range = Range1d(*y_range)
+    if x_range is not None:
+        plot.x_range = Range1d(*x_range)
+
     return plot
 
 
@@ -316,6 +326,8 @@ def create_solar_orbiter_layout() -> Row:
                 y_axis_label="Latitude separation (deg)",
                 unit="angle",
                 radii=[10, 20],
+                y_range=(-22, 22),
+                x_range=(-22, 22),
             ),
         ]
     )


### PR DESCRIPTION
# Description

This PR limits the x/y-range in the second SO trajectory plot in the case where SO is out of view (as it is now). This matches what is in their current dashboard, where SO is not shown if out of range. It can still be viewed if you zoom out on the plot. 

Close #84 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))
