### PR TITLE
Update plot configuration and validation to plot only IMAP traces

### DIFF
--- a/main/config.py
+++ b/main/config.py
@@ -61,15 +61,11 @@ class PlotsConfig(BaseConfig):
         # Check the names of spacecraft provided for each trace
         for plot in self.plots:
             for measurement_id, measurement in plot.measurements.items():
-                invalid_spacecraft = [
-                    craft
-                    for craft in measurement.traces
-                    if craft not in self.spacecrafts
-                ]
-                if invalid_spacecraft:
-                    raise ValueError(
-                        f"Invalid spacecraft(s) ({', '.join(invalid_spacecraft)}) "
-                        f"provided for plot {plot.title} ({measurement_id})."
-                    )
+                for spacecraft in self.spacecrafts:
+                    if spacecraft not in measurement.traces:
+                        raise ValueError(
+                            f"Spacecraft {spacecraft} is missing from the traces "
+                            f"for plot {plot.title} ({measurement_id})."
+                        )
 
         return self

--- a/main/config/plots.toml
+++ b/main/config/plots.toml
@@ -1,7 +1,7 @@
 # Configuration file for the timeseries plots
 
-spacecrafts = ["IMAP", "SO"] # List of all spacecrafts to include
-default_spacecraft = "IMAP"  # The spacecraft to display as default
+spacecrafts = ["IMAP"]      # List of all spacecrafts to plot traces for
+default_spacecraft = "IMAP" # The spacecraft to display as default
 
 [[plots]]
 title = "Magnetic field"

--- a/main/plots.py
+++ b/main/plots.py
@@ -100,6 +100,7 @@ def update_legend_on_spacecraft_selection(plot: figure) -> figure:
 
 def create_timeseries_plot(
     plot_config: PlotConfig,
+    spacecrafts: list[str],
     x_range: Range1d,
     time_range: str = "3d",
     default_spacecraft: str = "IMAP",
@@ -110,6 +111,7 @@ def create_timeseries_plot(
         plot_config: A Pydantic model containing fields for the title, unit and
             measurements. The measurements are Pydantic models containing their label
             and colours to be used for the traces for each spacecraft.
+        spacecrafts: A list of spacecraft names to include in the plot.
         x_range: The shared x-axis range for the plots.
         time_range: The initial time range for the data to display (default is 3 days).
         default_spacecraft: The spacecraft data to display as default.
@@ -129,7 +131,7 @@ def create_timeseries_plot(
     plot.lod_threshold = None
 
     for measurement, args in plot_config.measurements.items():
-        for spacecraft, colour in args.traces.items():
+        for spacecraft in spacecrafts:
             # Create an AjaxDataSource for each spacecraft and measurement
             source = AjaxDataSource(
                 data_url=f"/data/{measurement}/{spacecraft}?range={time_range}",
@@ -141,7 +143,7 @@ def create_timeseries_plot(
                 "date",
                 "measurement",
                 name=spacecraft,  # Enables selecting data in callback
-                color=colour,
+                color=args.traces[spacecraft],
                 source=source,
                 legend_label=f"{spacecraft}: {args.label}",
                 visible=spacecraft == default_spacecraft,
@@ -159,6 +161,7 @@ def create_timeseries_plot(
 
 def create_timeseries_plots(
     plots_config: list[PlotConfig],
+    spacecrafts: list[str],
     button: CheckboxButtonGroup,
     default_spacecraft: str = "IMAP",
     initial_time_range: str = "3d",
@@ -168,6 +171,7 @@ def create_timeseries_plots(
     Args:
         plots_config: A list of PlotConfig objects containing the config arguments for
             each plot, as defined in the config TOML file.
+        spacecrafts: A list of spacecraft names to include in the plots.
         button: A checkbox button to select the spacecraft to display data for.
         default_spacecraft: The spacecraft data to display as default.
         initial_time_range: The initial time range for the data to display.
@@ -195,7 +199,11 @@ def create_timeseries_plots(
     plots = []
     for plot_config in plots_config:
         plot = create_timeseries_plot(
-            plot_config, shared_x_range, initial_time_range, default_spacecraft
+            plot_config,
+            spacecrafts,
+            shared_x_range,
+            initial_time_range,
+            default_spacecraft,
         )
         plot.add_tools(hover, crosshair)
         add_callback_to_checkbox_button(plot=plot, button=button)
@@ -219,7 +227,7 @@ def create_timeseries_layout() -> Column:
     button = checkbox_button_group(spacecrafts, default_spacecraft)
     time_dropdown = create_time_range_dropdown()
     plots = create_timeseries_plots(
-        plots_config, button, default_spacecraft, time_dropdown.value
+        plots_config, spacecrafts, button, default_spacecraft, time_dropdown.value
     )
     add_time_range_callback(time_dropdown, plots)
 

--- a/tests/main/test_plots.py
+++ b/tests/main/test_plots.py
@@ -32,9 +32,10 @@ def test_create_timeseries_plot():
         },
     )
 
+    spacecrafts = ["A", "B"]
     x_range = figure(x_axis_type="datetime").x_range
 
-    plot = create_timeseries_plot(plot_config, x_range, time_range="7d")
+    plot = create_timeseries_plot(plot_config, spacecrafts, x_range, time_range="7d")
 
     assert isinstance(plot, figure)
 
@@ -100,7 +101,9 @@ def test_create_timeseries_plots():
         with patch("main.plots.AjaxDataSource") as data_source_mock:
             data_source_mock.return_value = source
 
-            plots = create_timeseries_plots(plots_config, button, default_spacecraft)
+            plots = create_timeseries_plots(
+                plots_config, spacecrafts, button, default_spacecraft
+            )
             assert len(plots) == 2
             assert all(isinstance(plot, figure) for plot in plots)
 

--- a/tests/main/test_widgets.py
+++ b/tests/main/test_widgets.py
@@ -31,11 +31,12 @@ def test_add_callback_to_checkbox_button(process_data_mock: Mock):
         },
     )
 
+    spacecrafts = ["A", "B"]
     default_spacecraft = "A"
 
     x_range = Range1d(start=0, end=1)
 
-    plot = create_timeseries_plot(plot_config, x_range, default_spacecraft)
+    plot = create_timeseries_plot(plot_config, spacecrafts, x_range, default_spacecraft)
 
     with patch.object(CheckboxButtonGroup, "js_on_event") as js_mock:
         add_callback_to_checkbox_button(plot, button)


### PR DESCRIPTION
# Description

This PR tweaks `plots.toml` and `plots.py` so that only the spacecraft in the `spacecrafts` option are plotted whilst still allowing trace configuration for other spacecraft even if they're not plotted. Also stets the `spacecrafts` option to only IMAP. This is necessary in production as we don't yet have the database source for Solar Orbiter and all requests for that data generate exceptions which are flooding the web app logs. Need to prevent the traces from actually being created like this as currently even if the SO traces are hidden they still make data requests to the backend.

When we want to enable SO later or for local development we just add it back at the top of `plots.toml`.

Close # (issue)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))
