### PR TITLE
Allow flexible use of the range_param when requesting data

### DIFF
--- a/main/utils.py
+++ b/main/utils.py
@@ -119,6 +119,8 @@ def get_gse_magnetic_field(
         f"{(timezone.now() - start_time).total_seconds():.2f} seconds to retrieve "
         f"{len(data)} records."
     )
+    if not len(data):
+        return {"measurement": [], "date": []}
 
     # Do some post processing to sanitize the data
     data = data.rename(columns={data.columns[0]: "date"})


### PR DESCRIPTION
# Description

This PR moves from allowing a fixed set of values for `range_param` when requesting data to plot to allowing any arbitrary string that can be processed by `pandas.Timedelta`. This inherently retains the same behaviour for 1d, 3d, 7d whilst also allowing much more flexible requests. This will be useful in production for testing how performance scales with query size.

Whlist implementing I also noticed that the current pandas logic doesn't handle the case of there being no data from the database very nicely so added a graceful empty response for that case.

Close # (issue)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))
