### PR TITLE
Fix so plot

### DIFF
--- a/main/plots.py
+++ b/main/plots.py
@@ -269,7 +269,6 @@ def create_solar_orbiter_plot(
         match_aspect=True,
         x_axis_label=x_axis_label,
         y_axis_label=y_axis_label,
-        sizing_mode="stretch_width",
     )
 
     # Create an AjaxDataSource for the spacecraft static position


### PR DESCRIPTION
# Description

Fixes bug by removing `sizing_mode="stretch_width"` from SO plots (which caused the plots to disappear)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))
