### PR TITLE
Hide pass data when SO is deselected

### DIFF
--- a/main/widgets.py
+++ b/main/widgets.py
@@ -74,6 +74,11 @@ def add_callback_to_checkbox_button(
             //  Hide or show 'Show Pass Data' checkbox based on whether "SO" is selected
             if (typeof pass_checkbox !== 'undefined') {
                 pass_checkbox.visible = is_so_active;
+
+                // If "SO" is not selected uncheck the 'Show Pass Data' checkbox
+                if (!is_so_active) {
+                    pass_checkbox.active = [];
+                }
             }
 
             // Hide or show the pass data strips on plots


### PR DESCRIPTION
# Description

The contact data should appear only when the SO option is selected. However, if SO is selected and deselected, the vstrip and contact schedule checkbox disappear, but the text label still stays on the plot. That should also disappear.

Fixed by unchecking 'Show Pass Data' checkbox when `SO` is deselected.

Close #159 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [x] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ x Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))
