### PR TITLE
Handle error when pulling trajectories

### DIFF
--- a/main/trajectory.py
+++ b/main/trajectory.py
@@ -1,6 +1,7 @@
 """Plots for displaying trajectory data."""
 
 from datetime import datetime
+from logging import getLogger
 from typing import cast
 
 import astropy.units as u
@@ -10,6 +11,8 @@ from sunpy.coordinates import get_body_heliographic_stonyhurst, get_horizons_coo
 from sunpy.coordinates.frames import GeocentricSolarEcliptic, HeliographicStonyhurst
 
 from .utils import get_message_template, get_solar_orbiter_dates, load_l1_config
+
+logger = getLogger(__name__)
 
 
 def heliographic_to_cartesian(
@@ -72,9 +75,15 @@ def get_JPL_spacecraft_coordinates(
         The coordinate or list of coordinates as Astropy SkyCoord(s).
     """
     if isinstance(time, tuple):
-        return get_horizons_coord(
-            spacecraft, {"start": time[0], "stop": time[-1], "step": "1d"}
-        )
+        try:
+            return get_horizons_coord(
+                spacecraft, {"start": time[0], "stop": time[-1], "step": "1d"}
+            )
+        except RuntimeError:
+            logger.error(
+                f"Error pulling coordinate range from JPL for spacecraft {spacecraft}."
+            )
+            return []
     else:
         return get_horizons_coord(spacecraft, time)
 


### PR DESCRIPTION
# Description

When pulling trajectory data from JPL, there're always a lot of errors that results in the logs being polluted with HTML and JS data, mostly useless as it does not contain information about what the error is about. Eventually, pulling the trajectory works without errors, but in the meantime, it makes very difficult to debug. It is unclear why this is happening. For now, we are just logging the error and returning an empty list, which also returns in an error, but at least is understandable. 

Close # (issue)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))
