### PR TITLE
Add labels and markers to L1 spacecrafts

### DIFF
--- a/main/config.py
+++ b/main/config.py
@@ -77,8 +77,14 @@ class L1SpacecraftConfig(BaseConfig):
     name: str
     """The name of the spacecraft."""
 
+    label: str
+    """The label used to identify the marker in the plot."""
+
     colour: str
     """The RGB colour for the spacecraft in the plot."""
+
+    marker: str
+    """The shape of the marker for the spacecraft in the plot."""
 
     id: int
     """The ID for the spacecraft to access JPL Horizons coordinates."""

--- a/main/config/l1_plot.toml
+++ b/main/config/l1_plot.toml
@@ -2,30 +2,42 @@
 
 [[spacecraft]]
 name = "IMAP"
+label = "I"
 colour = "rgb(255,143,0)"
+marker = "circle"
 id = -43
 
 [[spacecraft]]
 name = "ACE"
+label = "Ac"
 colour = "rgb(204,0,204)"
+marker = "diamond"
 id = -92
 
 [[spacecraft]]
 name = "WIND"
+label = "W"
 colour = "rgb(0,204,204)"
+marker = "inverted_triangle"
 id = -8
 
 [[spacecraft]]
 name = "DSCOVR"
+label = "D"
 colour = "rgb(0,102,204)"
+marker = "plus"
 id = -78
 
 [[spacecraft]]
 name = "Solar-1"
+label = "S"
 colour = "rgb(230,0,0)"
+marker = "square"
 id = -231
 
 [[spacecraft]]
 name = "Aditya-L1"
+label = "Ad"
 colour = "rgb(19,136,8)"
+marker = "triangle"
 id = -156

--- a/main/plots.py
+++ b/main/plots.py
@@ -13,6 +13,7 @@ from bokeh.models import (  # type: ignore
     CustomJS,
     HoverTool,
     Label,
+    LabelSet,
     LegendItem,
     Range1d,
     Span,
@@ -517,7 +518,13 @@ def create_l1_plot(
         method="GET",
     )
     objects = plot.scatter(
-        "y", "z", color="colour", legend_field="name", size=15, source=static_source
+        "y",
+        "z",
+        color="colour",
+        marker="marker",
+        legend_field="name",
+        size=15,
+        source=static_source,
     )
 
     # Create an AjaxDataSource for the trajectory data
@@ -552,6 +559,12 @@ def create_l1_plot(
             line_alpha=0,
         )
         plot.add_layout(arrow)
+
+    # Add the labels to the spacecraft markers
+    labels = LabelSet(
+        x="y", y="z", text="label", x_offset=5, y_offset=5, source=static_source
+    )
+    plot.add_layout(labels)
 
     # Add item to legend to describe line representation
     plot.line(

--- a/main/trajectory.py
+++ b/main/trajectory.py
@@ -274,7 +274,7 @@ def l1_data(
     """
     config = load_l1_config()
 
-    y_coords, z_coords, names, colours = [], [], [], []
+    y_coords, z_coords, names, labels, colours, markers = [], [], [], [], [], []
     for craft_config in config.spacecraft:
         trajectory = get_JPL_spacecraft_coordinates(craft_config.id, times)
         gse_trajectory = [coord_to_gse(coord) for coord in trajectory]
@@ -283,7 +283,9 @@ def l1_data(
         y_coords.append([coord[0] for coord in gse_trajectory])
         z_coords.append([coord[1] for coord in gse_trajectory])
         names.append(craft_config.name)
+        labels.append(craft_config.label)
         colours.append(craft_config.colour)
+        markers.append(craft_config.marker)
 
     # Get idxs for current coordinate and past/future arrows
     n = len(y_coords[0])
@@ -293,7 +295,9 @@ def l1_data(
 
     static_data = {
         "name": names,
+        "label": labels,
         "colour": colours,
+        "marker": markers,
         # middle date represents the current date
         "y": [coords[current] for coords in y_coords],
         "z": [coords[current] for coords in z_coords],


### PR DESCRIPTION
# Description

So they are easier to distinguish and comply with accessibility standards. The labels always appears top-right of the markers, meaning that there will be occasions when the trajectory overlaps with the label. There's no easy workaround this. The fact the the spacecrafts have different markers, should still help to identify them.

<img width="1366" height="444" alt="Screenshot From 2026-06-08 13-54-35" src="https://github.com/user-attachments/assets/767f4a52-81bb-4313-b233-0e80396c04be" />


Close #180

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))
