### PR TITLE
Add temp, density and speed from IMAP SWAPI to plots

### DIFF
--- a/main/data/load_example_data.py
+++ b/main/data/load_example_data.py
@@ -62,12 +62,16 @@ density = np.random.normal(loc=3.95, scale=0.22, size=len(swapi_times))
 speed = np.random.normal(loc=388.5, scale=0.6, size=len(swapi_times))
 temperature = np.random.normal(loc=27400, scale=380, size=len(swapi_times))
 
+density = density.clip(3.55, 4.35).round(2)
+speed = speed.clip(387, 390).round(2)
+temperature = temperature.clip(26600, 28200).round(2)
+
 swapi_data = [
     IMAPSWAPI(
         time=t,
-        proton_density=round(min(max(float(density_i), 3.55), 4.35), 2),
-        proton_speed=float(round(min(max(float(speed_i), 387), 390))),
-        proton_temperature=float(round(min(max(float(temperature_i), 26600), 28200))),
+        density=density_i,
+        speed=speed_i,
+        temperature=temperature_i,
     )
     for t, density_i, speed_i, temperature_i in zip(
         swapi_times, density, speed, temperature

--- a/main/data/load_example_data.py
+++ b/main/data/load_example_data.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 from django.utils import timezone
 
-from main.models import MAG_MODELS, SOContactSchedule
+from main.models import IMAPSWAPI, MAG_MODELS, SOContactSchedule
 
 # Define the times
 now = timezone.now()
@@ -45,6 +45,37 @@ for model in MAG_MODELS.values():
 
     # And add it to the DB in bulk
     model.objects.bulk_create(mfield)  # type: ignore[attr-defined]
+
+########################################################################################
+# Load IMAP SWAPI data
+########################################################################################
+
+swapi_times = pd.date_range(
+    start=now - pd.Timedelta(days=10), end=now, freq="20s"
+).to_series()
+
+# Remove existing SWAPI rows and replace with fresh examples.
+IMAPSWAPI.objects.all().delete()
+
+# Add data
+density = np.random.normal(loc=3.95, scale=0.22, size=len(swapi_times))
+speed = np.random.normal(loc=388.5, scale=0.6, size=len(swapi_times))
+temperature = np.random.normal(loc=27400, scale=380, size=len(swapi_times))
+
+swapi_data = [
+    IMAPSWAPI(
+        time=t,
+        proton_density=round(min(max(float(density_i), 3.55), 4.35), 2),
+        proton_speed=float(round(min(max(float(speed_i), 387), 390))),
+        proton_temperature=float(round(min(max(float(temperature_i), 26600), 28200))),
+    )
+    for t, density_i, speed_i, temperature_i in zip(
+        swapi_times, density, speed, temperature
+    )
+]
+
+# Add the data to the DB in bulk
+IMAPSWAPI.objects.bulk_create(swapi_data)
 
 ########################################################################################
 # Load SO contact schedule (pass) data

--- a/main/models.py
+++ b/main/models.py
@@ -92,13 +92,13 @@ class IMAPSWAPI(models.Model):
         db_column="id",
     )
 
-    proton_density = models.FloatField(
+    density = models.FloatField(
         help_text="Proton density in cm^-3.", db_column="swapi_pseudo_proton_density"
     )
-    proton_speed = models.FloatField(
+    speed = models.FloatField(
         help_text="Proton speed in km/s.", db_column="swapi_pseudo_proton_speed"
     )
-    proton_temperature = models.FloatField(
+    temperature = models.FloatField(
         help_text="Proton temperature in K.",
         db_column="swapi_pseudo_proton_temperature",
     )

--- a/main/models.py
+++ b/main/models.py
@@ -82,5 +82,31 @@ class SOContactSchedule(models.Model):
         managed = False
 
 
+class IMAPSWAPI(models.Model):
+    """Model describing the SWAPI data for IMAP."""
+
+    time = models.DateTimeField(
+        primary_key=True,
+        null=False,
+        help_text="Time for the data.",
+        db_column="id",
+    )
+
+    proton_density = models.FloatField(
+        help_text="Proton density in cm^-3.", db_column="swapi_pseudo_proton_density"
+    )
+    proton_speed = models.FloatField(
+        help_text="Proton speed in km/s.", db_column="swapi_pseudo_proton_speed"
+    )
+    proton_temperature = models.FloatField(
+        help_text="Proton temperature in K.",
+        db_column="swapi_pseudo_proton_temperature",
+    )
+
+    class Meta:  # noqa: D106
+        db_table = "imap_swapi"
+        managed = False
+
+
 MAG_MODELS = {"IMAP": IMAPGSEMagneticField, "SO": SOGSEMagneticField}
 """Models to handle magnetic data for the supported missions."""

--- a/main/utils.py
+++ b/main/utils.py
@@ -250,7 +250,7 @@ def get_imap_swapi_data(measurement: str, from_date: int) -> dict[str, list[floa
 
     Args:
         measurement: Name of the measurement to get data for - density, speed or
-        temperature.
+            temperature.
         from_date: The date to use as the starting point to get data (in ms format).
 
     Returns:

--- a/main/utils.py
+++ b/main/utils.py
@@ -19,12 +19,6 @@ from .config import L1Config, PlotsConfig
 
 logger = getLogger("django")
 
-IMAP_SWAPI_MEASUREMENTS = {
-    "density": "proton_density",
-    "speed": "proton_speed",
-    "temperature": "proton_temperature",
-}
-"""Map generic measurement names to IMAP SWAPI model field names."""
 
 BATCH_SIZE = 20000
 """Maximum numbers of data points to return per query.
@@ -129,7 +123,7 @@ def retrieve_data(
     ):
         return get_gse_magnetic_field(spacecraft, measurement, from_date)
 
-    if spacecraft == "IMAP" and measurement in IMAP_SWAPI_MEASUREMENTS:
+    if spacecraft == "IMAP" and measurement in ("density", "speed", "temperature"):
         return get_imap_swapi_data(measurement, from_date)
 
     if spacecraft in hapi.SPACECRAFTS:
@@ -257,14 +251,6 @@ def get_imap_swapi_data(measurement: str, from_date: int) -> dict[str, list[floa
         A dictionary containing the relevant datetimes in UNIX epoch time format and
             the measurements to plot.
     """
-    if measurement not in IMAP_SWAPI_MEASUREMENTS:
-        raise ValueError(
-            "Only IMAP SWAPI density, speed and temperature can be retrieved by "
-            "this function."
-        )
-
-    measurement_field = IMAP_SWAPI_MEASUREMENTS[measurement]
-
     # Get the relevant data from the DB
     most_recent = datetime.fromtimestamp(int(from_date) / 1000, tz=UTC)
     start_time = timezone.now()
@@ -272,7 +258,7 @@ def get_imap_swapi_data(measurement: str, from_date: int) -> dict[str, list[floa
         models.IMAPSWAPI.objects.filter(time__gt=most_recent)
         .annotate(date=TruncMinute("time"))
         .values("date")
-        .annotate(average=Avg(measurement_field))
+        .annotate(average=Avg(measurement))
         .order_by("date")
     )
     data = pd.DataFrame(list(dataquery))

--- a/main/utils.py
+++ b/main/utils.py
@@ -19,6 +19,13 @@ from .config import L1Config, PlotsConfig
 
 logger = getLogger("django")
 
+IMAP_SWAPI_MEASUREMENTS = {
+    "density": "proton_density",
+    "speed": "proton_speed",
+    "temperature": "proton_temperature",
+}
+"""Map generic measurement names to IMAP SWAPI model field names."""
+
 BATCH_SIZE = 20000
 """Maximum numbers of data points to return per query.
 
@@ -122,6 +129,9 @@ def retrieve_data(
     ):
         return get_gse_magnetic_field(spacecraft, measurement, from_date)
 
+    if spacecraft == "IMAP" and measurement in IMAP_SWAPI_MEASUREMENTS:
+        return get_imap_swapi_data(measurement, from_date)
+
     if spacecraft in hapi.SPACECRAFTS:
         return hapi.get_data_from_hapi(spacecraft, measurement, from_date)
 
@@ -223,6 +233,57 @@ def get_gse_magnetic_field(
         return {"measurement": [], "date": []}
 
     # Do some post processing to sanitize the data
+    data["date"] = pd.to_datetime(data["date"], utc=True)
+    data = reindex_data(data)
+
+    # Format datetime as Unix epoch time
+    data.index = data.index.astype("int64") // 10**3
+
+    # Create JSON response
+    dates = data.index.tolist()
+    measurements = data["average"].tolist()
+    return {"measurement": measurements, "date": dates}
+
+
+def get_imap_swapi_data(measurement: str, from_date: int) -> dict[str, list[float]]:
+    """Retrieves a component of the SWAPI data for the IMAP mission.
+
+    Args:
+        measurement: Name of the measurement to get data for - density, speed or
+        temperature.
+        from_date: The date to use as the starting point to get data (in ms format).
+
+    Returns:
+        A dictionary containing the relevant datetimes in UNIX epoch time format and
+            the measurements to plot.
+    """
+    if measurement not in IMAP_SWAPI_MEASUREMENTS:
+        raise ValueError(
+            "Only IMAP SWAPI density, speed and temperature can be retrieved by "
+            "this function."
+        )
+
+    measurement_field = IMAP_SWAPI_MEASUREMENTS[measurement]
+
+    # Get the relevant data from the DB
+    most_recent = datetime.fromtimestamp(int(from_date) / 1000, tz=UTC)
+    start_time = timezone.now()
+    dataquery = (
+        models.IMAPSWAPI.objects.filter(time__gt=most_recent)  # type: ignore[attr-defined]
+        .annotate(date=TruncMinute("time"))
+        .values("date")
+        .annotate(average=Avg(measurement_field))
+        .order_by("date")
+    )
+    data = pd.DataFrame(dataquery)
+    logger.info(
+        f"Querying IMAP SWAPI {measurement} data from the DB took "
+        f"{(timezone.now() - start_time).total_seconds():.2f} seconds to retrieve "
+        f"{len(data)} records. Start time is {most_recent}."
+    )
+    if not len(data):
+        return {"measurement": [], "date": []}
+
     data["date"] = pd.to_datetime(data["date"], utc=True)
     data = reindex_data(data)
 

--- a/main/utils.py
+++ b/main/utils.py
@@ -269,13 +269,13 @@ def get_imap_swapi_data(measurement: str, from_date: int) -> dict[str, list[floa
     most_recent = datetime.fromtimestamp(int(from_date) / 1000, tz=UTC)
     start_time = timezone.now()
     dataquery = (
-        models.IMAPSWAPI.objects.filter(time__gt=most_recent)  # type: ignore[attr-defined]
+        models.IMAPSWAPI.objects.filter(time__gt=most_recent)
         .annotate(date=TruncMinute("time"))
         .values("date")
         .annotate(average=Avg(measurement_field))
         .order_by("date")
     )
-    data = pd.DataFrame(dataquery)
+    data = pd.DataFrame(list(dataquery))
     logger.info(
         f"Querying IMAP SWAPI {measurement} data from the DB took "
         f"{(timezone.now() - start_time).total_seconds():.2f} seconds to retrieve "
@@ -291,8 +291,11 @@ def get_imap_swapi_data(measurement: str, from_date: int) -> dict[str, list[floa
     data.index = data.index.astype("int64") // 10**3
 
     # Create JSON response
-    dates = data.index.tolist()
-    measurements = data["average"].tolist()
+    dates = [float(timestamp) for timestamp in data.index.tolist()]
+    measurements = [
+        float(value)
+        for value in pd.to_numeric(data["average"], errors="coerce").tolist()
+    ]
     return {"measurement": measurements, "date": dates}
 
 

--- a/tests/main/test_utils.py
+++ b/tests/main/test_utils.py
@@ -160,7 +160,7 @@ def test_get_imap_swapi_data_density(days, measurement_type):
     actual = get_imap_swapi_data(measurement_type, from_date=from_date)
     expected_meas = list(
         IMAPSWAPI.objects.filter(time__in=times[-num:]).values_list(
-            f"proton_{measurement_type}", flat=True
+            measurement_type, flat=True
         )
     )
     expected_dates = (times[-num:].astype("int64") // 10**3).to_list()

--- a/tests/main/test_utils.py
+++ b/tests/main/test_utils.py
@@ -135,3 +135,38 @@ def test_get_message_template():
         ):
             message = get_message_template(date)
             assert message == "SO is not in communication until 1 January 2026."
+
+
+@pytest.mark.parametrize("days", [1, 3, 7])
+@pytest.mark.parametrize("measurement_type", ["density", "speed", "temperature"])
+@pytest.mark.django_db(databases=["imap"])
+def test_get_imap_swapi_data_density(days, measurement_type):
+    """Test the get_imap_swapi_data function."""
+    from main.models import IMAPSWAPI
+    from main.utils import get_imap_swapi_data
+
+    num = days * 24
+    now = datetime(2024, 6, 1, 12, 0, 0)  # Fixed current time for testing
+    times = (
+        pd.date_range(start=now - pd.Timedelta(days=10), end=now, freq="h")
+        .round("min")
+        .to_series()
+    )
+    from_date = int((now - pd.Timedelta(days=days)).timestamp()) * 1000
+
+    baker.make(IMAPSWAPI, time=itertools.cycle(times), _quantity=len(times))
+
+    # Find the actual and expected values
+    actual = get_imap_swapi_data(measurement_type, from_date=from_date)
+    expected_meas = list(
+        IMAPSWAPI.objects.filter(time__in=times[-num:]).values_list(
+            f"proton_{measurement_type}", flat=True
+        )
+    )
+    expected_dates = (times[-num:].astype("int64") // 10**3).to_list()
+
+    assert list(actual.keys()) == ["measurement", "date"]
+    assert len(actual["measurement"]) == num
+    assert len(actual["date"]) == num
+    assert expected_dates == actual["date"]
+    assert expected_meas == actual["measurement"]


### PR DESCRIPTION
# Description

Added temp, density and speed from IMAP SWAPI to plots.

No plan to add the HIT and SWE data for the moment.

Close #224 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [x] The documentation builds and looks OK (eg. `mkdocs serve`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))
